### PR TITLE
[Gnome Shell] fix window-clone-border radius

### DIFF
--- a/src/gnome-shell/gnome-shell-compact.css
+++ b/src/gnome-shell/gnome-shell-compact.css
@@ -1524,7 +1524,7 @@ Gjs_ArcMenu_ApplicationsButton.panel-button {
 .events-section-title {
   min-height: 20px;
   padding: 4px 8px;
-  border-radius: 100px;
+  border-radius: 5px;
   border: none;
   box-shadow: none;
   background: none;
@@ -2135,7 +2135,7 @@ Gjs_ArcMenu_ApplicationsButton.panel-button {
 
 .window-clone-border {
   border: 4px solid rgba(255, 255, 255, 0.3);
-  border-radius: 100px;
+  border-radius: 5px;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.3);
 }
 

--- a/src/gnome-shell/gnome-shell-dark-compact.css
+++ b/src/gnome-shell/gnome-shell-dark-compact.css
@@ -1524,7 +1524,7 @@ Gjs_ArcMenu_ApplicationsButton.panel-button {
 .events-section-title {
   min-height: 20px;
   padding: 4px 8px;
-  border-radius: 100px;
+  border-radius: 5px;
   border: none;
   box-shadow: none;
   background: none;
@@ -2135,7 +2135,7 @@ Gjs_ArcMenu_ApplicationsButton.panel-button {
 
 .window-clone-border {
   border: 4px solid rgba(255, 255, 255, 0.3);
-  border-radius: 100px;
+  border-radius: 5px;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.3);
 }
 

--- a/src/gnome-shell/gnome-shell-dark.css
+++ b/src/gnome-shell/gnome-shell-dark.css
@@ -1524,7 +1524,7 @@ Gjs_ArcMenu_ApplicationsButton.panel-button {
 .events-section-title {
   min-height: 24px;
   padding: 4px 8px;
-  border-radius: 100px;
+  border-radius: 5px;
   border: none;
   box-shadow: none;
   background: none;
@@ -2135,7 +2135,7 @@ Gjs_ArcMenu_ApplicationsButton.panel-button {
 
 .window-clone-border {
   border: 4px solid rgba(255, 255, 255, 0.3);
-  border-radius: 100px;
+  border-radius: 5px;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.3);
 }
 

--- a/src/gnome-shell/gnome-shell.css
+++ b/src/gnome-shell/gnome-shell.css
@@ -1524,7 +1524,7 @@ Gjs_ArcMenu_ApplicationsButton.panel-button {
 .events-section-title {
   min-height: 24px;
   padding: 4px 8px;
-  border-radius: 100px;
+  border-radius: 5px;
   border: none;
   box-shadow: none;
   background: none;
@@ -2135,7 +2135,7 @@ Gjs_ArcMenu_ApplicationsButton.panel-button {
 
 .window-clone-border {
   border: 4px solid rgba(255, 255, 255, 0.3);
-  border-radius: 100px;
+  border-radius: 5px;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.3);
 }
 

--- a/src/gnome-shell/sass/_variables.scss
+++ b/src/gnome-shell/sass/_variables.scss
@@ -32,7 +32,7 @@ $bar_size: 4px;
 $menuitem_size: if($laptop == 'false', 32px, 28px);
 
 // radiuses
-$material_radius: 100px;
+$material_radius: 5px;
 $bt_radius: 12px;
 $circular_radius: 9999px;
 


### PR DESCRIPTION
Hello

As seen in the picture below the `window-clone-border` radius is set too high, this is due to the last commit where `material_radius` has been set to `100px` (10a4ca2). This pull-request reverts `material_radius` back to `5px`. I'm not sure if I missed something but I don't think this will cause other problems.

![Screenshot from 2020-07-08 18-52-55](https://user-images.githubusercontent.com/7502104/86949095-743d3680-c14e-11ea-9c10-37ffa9e6cec8.png)
